### PR TITLE
Update practice template to better connect to step framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Material in this repository supports Pragmint's cyclical **S.T.E.P.** framework:
 
 * **Experiment:** Play around with supported [practices](/practices) to enhance targeted Capabilities. Select one or two high-impact experiments, commit to them, and give the team time to integrate them into their regular workflow.
 
-* **Polish:** Gather feedback and reflect on how experimenting with one or more practices affected the team's or system's performance. Review Metrics & Signals, included in each practice ([example](/practices/migrate-to-monorepo.md#metrics--signals)), to determine whether an experiment is making a positive impact. Adopt practices that are working, refine or scrap those that are not, then take the next S.T.E.P.
+* **Polish or Pitch:** Gather feedback and reflect on how experimenting with one or more practices affected the team's or system's performance. Review Metrics & Signals, included in each practice ([example](/practices/migrate-to-monorepo.md#metrics--signals)), to determine whether an experiment is making a positive impact. Polish and adopt practices that are working, refine or pitch those that are not, then take the next S.T.E.P.
 
 ## DORA Capabilities
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Material in this repository supports Pragmint's cyclical **S.T.E.P.** framework:
 
 * **Experiment:** Play around with supported [practices](/practices) to enhance targeted Capabilities. Select one or two high-impact experiments, commit to them, and give the team time to integrate them into their regular workflow.
 
-* **Polish or Pitch:** Gather feedback and reflect on how experimenting with one or more practices affected the team's or system's performance. Review Metrics & Signals, included in each practice ([example](/practices/migrate-to-monorepo.md#metrics--signals)), to determine whether an experiment is making a positive impact. Polish and adopt practices that are working, refine or pitch those that are not, then take the next S.T.E.P.
+* **Polish or Pitch:** Gather feedback and reflect on how experimenting with one or more practices affected the team's or system's performance. Review Metrics & Signals, included in each practice ([example](/practices/migrate-to-monorepo.md#metrics--signals)), to determine whether an experiment is making a positive impact. Polish and adopt practices that are working or showing promise, pitch those that are not, then take the next S.T.E.P.
 
 ## DORA Capabilities
 

--- a/practices/migrate-to-monorepo.md
+++ b/practices/migrate-to-monorepo.md
@@ -37,7 +37,7 @@ Schedule time with the team members who work in the new repository to understand
 
 ## Deciding to Polish or Pitch
 
-After experimenting with this practice for **one month**, bring the team together and ensure the following metrics and/or signals have changed in a positive direction:
+After experimenting with this practice for **one month**, bring the team together to determine whether the following metrics and/or signals have changed in a positive direction:
 
 ### Fast & Measurable
 

--- a/practices/migrate-to-monorepo.md
+++ b/practices/migrate-to-monorepo.md
@@ -9,7 +9,7 @@ Managing dozens of micro-repos can feel like death by a thousand Git pulls. This
 - [Pants](https://www.pantsbuild.org/stable/docs/using-pants/environments#in-workspace-execution-experimental_workspace_environment)
 - etc (this isn't by any means a definitive list)
 
-## Who It’s For & Why
+## When to Experiment
 
 - You are a Developer and you need to make coordinated changes across services without repo-hopping so you can move faster with less friction.
 
@@ -27,16 +27,6 @@ Give teams an easy way to migrate their repositories into the new workspace whil
 
 Schedule time with the team members who work in the new repository to understand their pain points. Brainstorm potential solutions as a group. Keep an eye toward improving the items listed in the Goals, Metrics & Signals section of this page to ensure efforts are making a difference.
 
-## Metrics & Signals
-
-### Fast & Measurable
-
-Within weeks, the lead time for changes spanning multiple repositories should decrease. By consolidating services into a monorepo, cross-cutting changes can be made without repo-hopping or chaining pull requests across repos, reducing coordination overhead and speeding up delivery. Tools like [DX](https://getdx.com/platform/data-lake/), [Jellyfish](https://jellyfish.co/platform/engineering-metrics/), or others can measure these sort of lead time changes. Custom solutions can also be built using data from project planning tools like [JIRA](https://community.atlassian.com/forums/App-Central-articles/Cycle-Time-and-Lead-Time-in-Jira-Productivity-Measurement-with/ba-p/1905845), [Monday](https://monday.com/blog/project-management/what-is-lead-time/), or others.
-
-### Slow & Intangible
-
-Over time, the system's service boundaries should feel cleaner because refactoring those boundaries becomes easier. Poor service boundaries can be removed with less friction when everything lives in one repo. On the flipside, teams can more quickly extract new services with the shared tooling, configuration, and build setup.
-
 ## Lessons From The Field
 
 - *It's Important to Preserve Revision History* - The easiest way to migrate over to a workspace tool is to copy/paste the source code into the subdirectories of a new repository. This blows the history away, and all of the rich version history will get lost in the process. If you're using Git, you can merge an external codebase using the `--allow-unrelated-histories` flag. It's probably best to stay away from using submodules as that can create a very clunky developer experience.
@@ -44,6 +34,18 @@ Over time, the system's service boundaries should feel cleaner because refactori
 - *Makes Tight Coupling Easier* - When you make it easier to write code that changes multiple parts of the broader system, you make it easier to introduce code that doesn't separate concerns and increases module coupling. This can be mitigated with constant retrospectives focused on how these boundaries are formed. The good news about monorepos is when you identify a poorly constructed boundary, it's easier to fix when it's all in the same repo.
 - *Have a plan for coordinating deploys* - When multiple modules need to be released together for a feature, it can be easier to coordinate activation through feature flags rather than trying to achieve atomic cross-package deployments.
 - *Only build and test what has actually changed between commits* - Good build tools use dependency graphs to determine which packages need rebuilding. Without this, CI/CD times become prohibitive as the repo grows.
+
+## Deciding to Polish or Pitch
+
+After experimenting with this practice for **one month**, bring the team together and ensure the following metrics and/or signals have changed in a positive direction:
+
+### Fast & Measurable
+
+**Lead Time** for changes spanning multiple repositories should decrease. By consolidating services into a monorepo, cross-cutting changes can be made without repo-hopping or chaining pull requests across repos, reducing coordination overhead and speeding up delivery. Tools like [DX](https://getdx.com/platform/data-lake/), [Jellyfish](https://jellyfish.co/platform/engineering-metrics/), or others can measure these sort of lead time changes. Custom solutions can also be built using data from project planning tools like [JIRA](https://community.atlassian.com/forums/App-Central-articles/Cycle-Time-and-Lead-Time-in-Jira-Productivity-Measurement-with/ba-p/1905845), [Monday](https://monday.com/blog/project-management/what-is-lead-time/), or others.
+
+### Slow & Intangible
+
+**Cleaner Service Boundaries** should evolve over time, because refactoring those boundaries becomes easier. Poor service boundaries can be removed with less friction when everything lives in one repo. On the flipside, teams can more quickly extract new services with the shared tooling, configuration, and build setup.
 
 ## Supporting Capabilities
 

--- a/templates/new-practice.md
+++ b/templates/new-practice.md
@@ -6,7 +6,7 @@
 Quick 2-4 sentence summary. What’s the practice? Why should teams care? Keep it casual and motivating.
 ```
 
-## Who It’s For & Why
+## When to Experiment
 
 ```text
 “I am a [persona] and I need to [learn how to / ensure that] so I can [end goal].”
@@ -22,24 +22,26 @@ Each step gets:
   3 sentences on how to do it, how to get buy-in, and what tools/resources help. Any external resources (videos, guides, book lists, templates, etc.) that help a team adopt this practice should be linked here within the relevant action step.
 ```
 
-## Metrics & Signals
-
-```text
-When writing Metrics & Signals, list target metrics, qualitative markers, or lightweight feedback mechanisms. 
-
-Organize them into Fast & Measurable, Fast & Intangible, Slow & Measurable, or Slow & Intangible, but only include categories with strong, defensible signals. Exclude weak or hard-to-attribute signals.
-
-For measurable items, specify how to track them (e.g., DX, Jira, CI dashboards). For intangible items, note how to capture feedback (e.g., surveys, retro notes, developer chatter). 
-
-Keep metrics scoped and outcome-focused (e.g., “reduced lead time for cross-repo changes” instead of just “reduced lead time”). 
-```
-
 ## Lessons From The Field
 
 ```text
 This section captures real-world patterns (things that consistently help or hinder this practice) along with short, relevant stories from the field. It’s not for personal rants or generic opinions. Each entry must be based on either:
 1. a repeated observation across teams, or
 2. a specific example (what worked, what didn’t, and why).
+```
+
+## Deciding to Polish or Pitch
+
+After experimenting with this practice for `insert appropriate quantity of time in bold`, bring the team together and ensure the following metrics and/or signals have changed in a positive direction:
+
+```text
+When writing Metrics & Signals, list target metrics, qualitative markers, or lightweight feedback mechanisms.
+
+Organize them into Fast & Measurable, Fast & Intangible, Slow & Measurable, or Slow & Intangible, but only include categories with strong, defensible signals. Exclude weak or hard-to-attribute signals.
+
+For measurable items, specify how to track them (e.g., DX, Jira, CI dashboards). For intangible items, note how to capture feedback (e.g., surveys, retro notes, developer chatter).
+
+Keep metrics scoped and outcome-focused (e.g., “reduced lead time for cross-repo changes” instead of just “reduced lead time”).
 ```
 
 ## Supported Capabilities

--- a/templates/new-practice.md
+++ b/templates/new-practice.md
@@ -17,7 +17,7 @@ Quick 2-4 sentence summary. What’s the practice? Why should teams care? Keep i
 
 ```text
 List 3–5 steps to take a team from zero to adopted.
-Each step gets:
+For each step, include:
   ### [Action Step]
   3 sentences on how to do it, how to get buy-in, and what tools/resources help. Any external resources (videos, guides, book lists, templates, etc.) that help a team adopt this practice should be linked here within the relevant action step.
 ```
@@ -32,12 +32,12 @@ This section captures real-world patterns (things that consistently help or hind
 
 ## Deciding to Polish or Pitch
 
-After experimenting with this practice for `insert appropriate quantity of time in bold`, bring the team together and ensure the following metrics and/or signals have changed in a positive direction:
+After experimenting with this practice for [**insert appropriate quantity of time in bold**], bring the team together to determine whether the following metrics and/or signals have changed in a positive direction:
 
 ```text
-When writing Metrics & Signals, list target metrics, qualitative markers, or lightweight feedback mechanisms. Review this article for inspiration: https://dora.dev/research/2025/measurement-frameworks/
+List target metrics, qualitative markers, or lightweight feedback mechanisms. Review this article for inspiration: https://dora.dev/research/2025/measurement-frameworks/
 
-Organize them into Fast & Measurable, Fast & Intangible, Slow & Measurable, or Slow & Intangible, but only include categories with strong, defensible signals. Exclude weak or hard-to-attribute signals.
+Organize metrics and signals into Fast & Measurable, Fast & Intangible, Slow & Measurable, or Slow & Intangible, but only include categories with strong, defensible signals. Exclude weak or hard-to-attribute signals.
 
 For measurable items, specify how to track them (e.g., DX, Jira, CI dashboards). For intangible items, note how to capture feedback (e.g., surveys, retro notes, developer chatter).
 

--- a/templates/new-practice.md
+++ b/templates/new-practice.md
@@ -35,7 +35,7 @@ This section captures real-world patterns (things that consistently help or hind
 After experimenting with this practice for `insert appropriate quantity of time in bold`, bring the team together and ensure the following metrics and/or signals have changed in a positive direction:
 
 ```text
-When writing Metrics & Signals, list target metrics, qualitative markers, or lightweight feedback mechanisms.
+When writing Metrics & Signals, list target metrics, qualitative markers, or lightweight feedback mechanisms. Review this article for inspiration: https://dora.dev/research/2025/measurement-frameworks/
 
 Organize them into Fast & Measurable, Fast & Intangible, Slow & Measurable, or Slow & Intangible, but only include categories with strong, defensible signals. Exclude weak or hard-to-attribute signals.
 


### PR DESCRIPTION
Also, this PR introduces the pitch substitute for the polish phase. I came up with this idea while explaining the STEP process to a new member of the team. Thought it was catchy and makes it clear to the team that just b/c an experiment is happening, doesn't mean the practice is sticking around if it's not making a positive impact.

I was thinking through how to give co-dev coaches something they can take off the shelf for a retrospective that's targeted on a single practice and it dawned on me the metrics & signals section is that. However, it's not intuitive from the name of the section. So I refactored it once more to make that connection more explicit.